### PR TITLE
Fix Pink theme's reference to nonexist panel.png

### DIFF
--- a/theme-pink.conf
+++ b/theme-pink.conf
@@ -30,7 +30,7 @@ Top=6
 Bottom=6
 
 [InputPanel/Background]
-Image=panel.png
+Image=panel-pink.png
 
 [InputPanel/Background/Margin]
 Left=2


### PR DESCRIPTION
I believe it should be panel-pink.png here.